### PR TITLE
SGSI: miui-patch: Remove the cust mount script for rootdir

### DIFF
--- a/make/rom_make_patch/miui/make.sh
+++ b/make/rom_make_patch/miui/make.sh
@@ -3,9 +3,13 @@
 LOCALDIR=`cd "$( dirname $0 )" && pwd`
 cd $LOCALDIR
 
+systemrootdir="../../../out/system"
 systemdir="../../../out/system/system"
 configdir="../../../out/config"
 vendordir="../../../out/vendor"
+
+# 清除MIUI供应商分区挂载
+rm -f $systemrootdir/init.miui.cust.rc
 
 # 清除该死的miui推广上下文导致的几乎所有机型bootloop或者直接启动到rec
 sed -i '/miui.reverse.charge/d' $systemdir/system_ext/etc/selinux/system_ext_property_contexts


### PR DESCRIPTION
English:
* 1. The cust partition may not exist on other devices,
     and it would be useless to leave it here.

* 2. When Xiaomi devices use cust as vendor, for example: sagit - MI 6,
     it will mount the vendor back as cust at boot time, and will also
     cause SELinux warnings.

* 3. Most of the models that support ProjectTreble by default in Xiaomi
     will be listed in the vendor's fstab.qcom Mount the cust partition
     to cust in.

Chinese:
* 1. 在其他设备上可能不会存在cust分区, 留在这里也是无用的

* 2. 在Xiaomi设备使用cust作为vendor时, 例如: sagit - MI 6,
     会在引导时又将vendor挂载回为cust, 也会引起SELinux的警告

* 3. 在Xiaomi默认支持ProjectTreble的机型大多数会在vendor的fstab.qcom
     中将cust分区挂载到cust

  [From: sagit kernel dmesg]
  [    6.112501] selinux: SELinux: Could not set context for /cust/bin/expr:  Read-only file system
  [    6.112601] selinux: SELinux: Could not set context for /cust/bin/pm-service:  Read-only file system
  [    6.112699] selinux: SELinux: Could not set context for /cust/bin/toybox_vendor:  Read-only file system
  [    6.112779] selinux: SELinux: Could not set context for /cust/bin/chattr:  Read-only file system
  [    6.112859] selinux: SELinux: Could not set context for /cust/bin/touch:  Read-only file system
  [    6.112940] selinux: SELinux: Could not set context for /cust/bin/uptime:  Read-only file system
  [    6.113023] selinux: SELinux: Could not set context for /cust/bin/dirname:  Read-only file system
  [    6.113106] selinux: SELinux: Could not set context for /cust/bin/timeout:  Read-only file system
  [    6.113185] selinux: SELinux: Could not set context for /cust/bin/sort:  Read-only file system
  [    6.113292] selinux: SELinux: Could not set context for /cust/bin/init.panel_info.sh:  Read-only file system

[gerrit-merge-test-ok]
[gerrit-changes-test-ok]
[device: sagit changes_type: fix]

Signed-off-by: 赵悦男 <ZhaoYueNan@ZhaoYueNan>
Change-Id: I31dbf274078a1a3314535680a1cee4039caa9755