### PR TITLE
SGSI: Remove the LD_PRELOAD section of vndk.rc

### DIFF
--- a/make/add_phh/system/etc/init/vndk.rc
+++ b/make/add_phh/system/etc/init/vndk.rc
@@ -2,8 +2,7 @@ on post-fs
 	exec - root -- /system/bin/vndk-detect
 	exec - root -- /system/bin/rw-system.sh
 	mount none /system/etc/usb_audio_policy_configuration.xml /vendor/etc/usb_audio_policy_configuration.xml bind
-        setprop ro.vndk.version ${persist.sys.vndk}
-	export LD_PRELOAD :
+	setprop ro.vndk.version ${persist.sys.vndk}
 
 on property:vold.decrypt=trigger_restart_framework
 


### PR DESCRIPTION
[change merge 1/2]
[Reason for change]: Fixed the crash of China Netease. games after entering.
[Change purpose]: Fix project code
[Change test]: Pack the image normally, and start it.

[change merge 2/2]
external/SGSI: Align the vndk.rc part of the code
[Reason for change]: Align code
[Change purpose]: null
[Change test]: null.

Merge change test: Platform: Xiaomi MI 6 (sagit) MSM8998
  System: MIUI 13, original system model: MI CC9 Pro
  Install 2 games on the system:
   1. com.netease.sky 2. com.netease.x19
  Enter the game to play for 10 minutes,
  completely clear the background, run 10 times.
  No crash issues.

* Aquarius223: Since there is no historical commit record,
               I don't know what the LD_PRELOAD addition is to fix,
               but deleting it can fix the Chinese game crash.

Signed-off-by: 赵悦男 <ZhaoYueNan@ZhaoYueNanolx>
Change-Id: I087b327cfe389b4e89a2f677bd4970c64240d218