### PR TITLE
SGSI & setup.sh: Fix path and dependency

### DIFF
--- a/SGSI.sh
+++ b/SGSI.sh
@@ -600,7 +600,7 @@ function make_Aonly() {
   old_rc_flies=$(ls $systemdir/etc/init/hw)
   for old_rc in $old_rc_flies ;do
     new_rc=$(echo "${old_rc%.*}" | sed 's/$/&-treble.rc/g')
-    cp -frp $systemdir/etc/init/hw/$old_rc $system/etc/init/$new_rc
+    cp -frp $systemdir/etc/init/hw/$old_rc $systemdir/etc/init/$new_rc
   done 
   
   # 添加启动A-only必备文件 

--- a/setup.sh
+++ b/setup.sh
@@ -24,7 +24,7 @@ dependency_install(){
         echo -e "\033[33m [DEBUG] Linux Detected \033[0m"
         echo -e "\033[33m [INFO] Installing Packages via apt... \033[0m"
         sudo apt update && sudo apt upgrade -y
-        sudo apt install git p7zip openjdk-8-jdk curl cpio wget unace unrar zip unzip p7zip-full p7zip-rar sharutils uudeview mpack arj cabextract file-roller aptitude device-tree-compiler liblzma-dev liblz4-tool gawk aria2 selinux-utils busybox -y
+        sudo apt install git p7zip openjdk-8-jdk curl cpio wget unace unrar zip unzip p7zip-full p7zip-rar sharutils uudeview mpack arj cabextract file-roller aptitude device-tree-compiler liblzma-dev liblz4-tool gawk aria2 selinux-utils busybox bc -y
         sudo apt update --fix-missing
         
     elif [[ "$OSTYPE" == "darwin"* ]]; then


### PR DESCRIPTION
## Add `bc` dependency to `setup.sh`
It turns out that on my Debian 11, `bc` should be installed manually.
![](https://raw.githubusercontent.com/FanBB2333/picBed/main/img/20220729bc.png)
## Fix wrong target path for rc files
The `$system` var should be none if not manually set, it might should be `$systemdir`
![](https://raw.githubusercontent.com/FanBB2333/picBed/main/img/20220729cp.jpg)